### PR TITLE
VE: add suspend to subscriptionsDao methods

### DIFF
--- a/app/app/src/main/java/com/vlatrof/subscriptionsmanager/presentation/screens/subscriptiondetails/SubscriptionDetailsViewModelImpl.kt
+++ b/app/app/src/main/java/com/vlatrof/subscriptionsmanager/presentation/screens/subscriptiondetails/SubscriptionDetailsViewModelImpl.kt
@@ -61,7 +61,7 @@ class SubscriptionDetailsViewModelImpl(
 
     override fun loadSubscriptionById(id: Int) {
         viewModelScope.launch(mainDispatcher) {
-            subscriptionLiveData.value = getSubscriptionByIdUseCase(id).await()
+            subscriptionLiveData.value = getSubscriptionByIdUseCase(id)
         }
     }
 

--- a/app/data/src/main/java/com/vlatrof/subscriptionsmanager/data/local/SubscriptionsLocalDataSource.kt
+++ b/app/data/src/main/java/com/vlatrof/subscriptionsmanager/data/local/SubscriptionsLocalDataSource.kt
@@ -18,7 +18,7 @@ class SubscriptionsLocalDataSource(private val subscriptionsDao: SubscriptionsDa
             }
         }
 
-    fun getSubscriptionById(id: Int): DataSubscription {
+    suspend fun getSubscriptionById(id: Int): DataSubscription {
         return DataSubscription(subscriptionsDao.getById(id))
     }
 

--- a/app/data/src/main/java/com/vlatrof/subscriptionsmanager/data/local/room/dao/SubscriptionsDao.kt
+++ b/app/data/src/main/java/com/vlatrof/subscriptionsmanager/data/local/room/dao/SubscriptionsDao.kt
@@ -18,7 +18,7 @@ interface SubscriptionsDao {
     fun getAllFlow(): Flow<List<SubscriptionEntity>>
 
     @Query("SELECT * FROM subscriptions WHERE id=:id ")
-    fun getById(id: Int): SubscriptionEntity
+    suspend fun getById(id: Int): SubscriptionEntity
 
     @Query("DELETE FROM subscriptions")
     fun deleteAll()

--- a/app/data/src/main/java/com/vlatrof/subscriptionsmanager/data/repositories/SubscriptionsRepositoryImpl.kt
+++ b/app/data/src/main/java/com/vlatrof/subscriptionsmanager/data/repositories/SubscriptionsRepositoryImpl.kt
@@ -24,7 +24,7 @@ class SubscriptionsRepositoryImpl(
             }
         }
 
-    override fun getSubscriptionById(id: Int): DomainSubscription {
+    override suspend fun getSubscriptionById(id: Int): DomainSubscription {
         return subscriptionsLocalDataSource.getSubscriptionById(id).toDomainSubscription()
     }
 

--- a/app/domain/src/main/java/com/vlatrof/subscriptionsmanager/domain/repositories/SubscriptionsRepository.kt
+++ b/app/domain/src/main/java/com/vlatrof/subscriptionsmanager/domain/repositories/SubscriptionsRepository.kt
@@ -7,7 +7,7 @@ interface SubscriptionsRepository {
 
     val allSubscriptionsFlow: Flow<List<Subscription>>
 
-    fun getSubscriptionById(id: Int): Subscription
+    suspend fun getSubscriptionById(id: Int): Subscription
 
     fun insertSubscription(subscription: Subscription)
 

--- a/app/domain/src/main/java/com/vlatrof/subscriptionsmanager/domain/usecases/getbyid/GetSubscriptionByIdUseCase.kt
+++ b/app/domain/src/main/java/com/vlatrof/subscriptionsmanager/domain/usecases/getbyid/GetSubscriptionByIdUseCase.kt
@@ -5,5 +5,5 @@ import kotlinx.coroutines.Deferred
 
 interface GetSubscriptionByIdUseCase {
 
-    operator fun invoke(id: Int): Deferred<Subscription>
+    suspend operator fun invoke(id: Int): Subscription
 }

--- a/app/domain/src/main/java/com/vlatrof/subscriptionsmanager/domain/usecases/getbyid/GetSubscriptionByIdUseCaseImpl.kt
+++ b/app/domain/src/main/java/com/vlatrof/subscriptionsmanager/domain/usecases/getbyid/GetSubscriptionByIdUseCaseImpl.kt
@@ -2,10 +2,7 @@ package com.vlatrof.subscriptionsmanager.domain.usecases.getbyid
 
 import com.vlatrof.subscriptionsmanager.domain.models.Subscription
 import com.vlatrof.subscriptionsmanager.domain.repositories.SubscriptionsRepository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
+import kotlinx.coroutines.*
 
 class GetSubscriptionByIdUseCaseImpl(
 
@@ -13,9 +10,7 @@ class GetSubscriptionByIdUseCaseImpl(
 
 ) : GetSubscriptionByIdUseCase {
 
-    override fun invoke(id: Int): Deferred<Subscription> {
-        return CoroutineScope(Dispatchers.IO).async {
-            subscriptionsRepository.getSubscriptionById(id)
-        }
+    override suspend fun invoke(id: Int): Subscription = withContext(Dispatchers.IO) {
+        subscriptionsRepository.getSubscriptionById(id)
     }
 }


### PR DESCRIPTION
Суть:
 - все методы для работы с репозиториями должны помечаться suspend, т.к. они работаю с памятью и могут блокировать поток
 - хорошим тоном является переключение потоков в начале метода где это нужно (вот тут про это есть - https://developer.android.com/kotlin/coroutines/coroutines-best-practices), поэтому делаю переключение в UseCase, с помощью withContext(Dispatchers.IO) 